### PR TITLE
Clone gocode into full vendor path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,3 +35,6 @@
 [submodule "third_party/gocode"]
 	path = third_party/gocode
 	url = https://github.com/mdempsky/gocode.git
+[submodule "third_party/github.com/mdempsky/gocode"]
+	path = third_party/github.com/mdempsky/gocode
+	url = https://github.com/mdempsky/gocode

--- a/build.py
+++ b/build.py
@@ -605,7 +605,7 @@ def EnableCsCompleter( args ):
 def EnableGoCompleter( args ):
   go = FindExecutableOrDie( 'go', 'go is required to build gocode.' )
 
-  os.chdir( p.join( DIR_OF_THIS_SCRIPT, 'third_party', 'gocode' ) )
+  os.chdir( p.join( DIR_OF_THIS_SCRIPT, 'third_party', 'github.com', 'mdempsky', 'gocode' ) )
   CheckCall( [ go, 'build' ],
              quiet = args.quiet,
              status_message = 'Building gocode for go completion' )


### PR DESCRIPTION
This should update the PR you have: https://github.com/Valloric/ycmd/pull/1092. It seems Go needs the full package path to build correctly. godef circumvents this issue by using relative paths. The new gocode uses internal packages and absolute paths, so this is the only way around it (at least AFAIK).